### PR TITLE
fix(keycloak): use correct scope

### DIFF
--- a/apps/forge/src/main/fabric8/route.yml
+++ b/apps/forge/src/main/fabric8/route.yml
@@ -1,0 +1,7 @@
+spec:
+  to:
+    kind: Service
+    name: "forge"
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/apps/keycloak/src/main/fabric8/cm.yml
+++ b/apps/keycloak/src/main/fabric8/cm.yml
@@ -81,6 +81,7 @@ data:
           "config": {
             "baseUrl": "${K8S_API_SERVER}",
             "clientId": "fabric8-online-platform",
+            "defaultScope": "user:full",
             "clientSecret": "fabric8"
           }
         },


### PR DESCRIPTION
lets use the full user scope for openshift so that users get to view
    applications, pipelines and so forth