### PR TITLE
fix(readiness): add readiness check to DBs

### DIFF
--- a/apps/init-tenant/src/main/fabric8/db-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/db-deployment.yml
@@ -14,15 +14,37 @@ spec:
         service: init-tenant-db
     spec:
       containers:
-      - image: registry.centos.org/postgresql/postgresql:9.6
+      - name: init-tenant-db
+        image: registry.centos.org/postgresql/postgresql:9.6
+        imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRESQL_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: f8tenant
               key: postgres.password
-        imagePullPolicy: IfNotPresent
-        name: init-tenant-db
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5
         ports:
         - containerPort: 5432
           protocol: TCP

--- a/apps/keycloak/src/main/fabric8/keycloak-db-deployment.yml
+++ b/apps/keycloak/src/main/fabric8/keycloak-db-deployment.yml
@@ -12,7 +12,9 @@ spec:
         service: keycloak-db
     spec:
       containers:
-      - image: registry.centos.org/postgresql/postgresql:9.6
+      - name: keycloak-db
+        image: registry.centos.org/postgresql/postgresql:9.6
+        imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRESQL_DATABASE
           value: keycloak
@@ -20,8 +22,28 @@ spec:
           value: keycloak
         - name: POSTGRESQL_USER
           value: keycloak
-        imagePullPolicy: IfNotPresent
-        name: keycloak-db
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5
         ports:
         - containerPort: 5432
           protocol: TCP

--- a/apps/wit/src/main/fabric8/db-deployment.yml
+++ b/apps/wit/src/main/fabric8/db-deployment.yml
@@ -14,15 +14,37 @@ spec:
         service: wit-db
     spec:
       containers:
-      - image: registry.centos.org/postgresql/postgresql:9.6
+      - name: wit-db
+        image: registry.centos.org/postgresql/postgresql:9.6
+        imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRESQL_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               name: wit
               key: db.password
-        imagePullPolicy: IfNotPresent
-        name: wit-db
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
lets fix a timing issue I was getting frequently on openshift 3.6.0 with KC getting its DB corrupted
adding liveness and readiness checks to the DBs seems to help
fixes https://github.com/fabric8io/keycloak-deployment/issues/27