### PR TITLE
che-192: Adding env var for che-starter support on fabric8-platform (openshift.io deployment on minishift)

### DIFF
--- a/apps/che-starter/src/main/fabric8/cm.yml
+++ b/apps/che-starter/src/main/fabric8/cm.yml
@@ -8,6 +8,6 @@ type: Opaque
 data:
   oso.domain.name: localhost
   oso.address: localhost:8443
-  kubes.certs.ca.file: /opt/che-starter/tsrv.devshift.net.cer
   oso.tokenurl: http://keycloak/auth/realms/fabric8/broker/openshift-v3/token
   github.tokenurl: http://keycloak/auth/realms/fabric8/broker/github/token
+  fabric8.dev.mode: true

--- a/apps/che-starter/src/main/fabric8/deployment.yml
+++ b/apps/che-starter/src/main/fabric8/deployment.yml
@@ -26,11 +26,11 @@ spec:
               configMapKeyRef:
                 name: che-starter
                 key: oso.domain.name
-          - name: KUBERNETES_CERTS_CA_FILE
+          - name: FABRIC8_PLATFORM_DEV_MODE
             valueFrom:
               configMapKeyRef:
                 name: che-starter
-                key: kubes.certs.ca.file
+                key: fabric8.dev.mode
           name: che-starter
           image: rhche/che-starter:${che-starter.version}
           livenessProbe:


### PR DESCRIPTION
Should be applied after https://github.com/redhat-developer/che-starter/pull/193