### PR TITLE
lets default to proxying console REST calls but not WS

### DIFF
--- a/apps/fabric8/src/main/fabric8/cm.yml
+++ b/apps/fabric8/src/main/fabric8/cm.yml
@@ -4,22 +4,29 @@ metadata:
   name: fabric8
   annotations:
     # when using the proxy 
-    # apiserver.base.path: "/_p/oso"
-    expose.config.fabric8.io/url-key: proxy.pass.url
+    #expose.config.fabric8.io/url-key: proxy.pass.url
+    #expose.config.fabric8.io/url-key: proxy.pass.url
     #expose.config.fabric8.io/host-key: proxy.pass.server
-    #expose.config.fabric8.io/url-key: apiserver.url
-    #expose.config.fabric8.io/host-key: apiserver.host
+    expose.config.fabric8.io/url-key: apiserver.url
+    expose.config.fabric8.io/host-key: apiserver.host
     expose.config.fabric8.io/console-url-key: openshift.console.url
-    expose.config.fabric8.io/apiserver-key: apiserver.host
-    expose.config.fabric8.io/apiserver-url-key: apiserver.url
+    #expose.config.fabric8.io/apiserver-key: proxy.pass.server
+    expose.config.fabric8.io/apiserver-url-key: proxy.pass.url
+    expose.config.fabric8.io/apiserver-key: ws.apiserver.host
+    #expose.config.fabric8.io/apiserver-key: apiserver.host
+    #expose.config.fabric8.io/apiserver-url-key: apiserver.url
     expose-full.service-key.config.fabric8.io/sso: keycloak.url
     expose-full.service-key.config.fabric8.io/wit: wit.api.url
     expose.service-key.config.fabric8.io/forge: forge.api.url
-    expose.config.fabric8.io/apiserver-protocol-key: apiserver.protocol
+    #expose.config.fabric8.io/apiserver-protocol-key: apiserver.protocol
+    expose.config.fabric8.io/protocol-key: apiserver.protocol
 data:
   apiserver.host: kubernetes
   apiserver.url: http://kubernetes
-  apiserver.base.path: ""
+  apiserver.base.path: "/_p/oso"
+  ws.apiserver.host: kubernetes
+  ws.apiserver.base.path: ""
+  ws.apiserver.protocol: wss
   proxy.pass.server: ""
   proxy.pass.url: ""
   apiserver.protocol: http

--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -79,4 +79,19 @@ spec:
             configMapKeyRef:
               name: fabric8
               key: apiserver.base.path
+        - name: "WS_K8S_API_SERVER_BASE_PATH"
+          valueFrom:
+            configMapKeyRef:
+              name: fabric8
+              key: ws.apiserver.base.path
+        - name: "WS_K8S_API_SERVER_PROTOCOL"
+          valueFrom:
+            configMapKeyRef:
+              name: fabric8
+              key: ws.apiserver.protocol
+        - name: "WS_K8S_API_SERVER"
+          valueFrom:
+            configMapKeyRef:
+              name: fabric8
+              key: ws.apiserver.host
 


### PR DESCRIPTION
lets always proxy REST calls so that the console works whether or not CORS is enabled on a kubernetes/openshift cluster
proxying of WS does not work with our nginx proxy and kubernetes/openshift so lets always go direct for WS traffic without a proxy
then if CORS is not enabled we'll fail back to polling for WS traffic until we figure out a WS proxy that works with kubernetes watches