### PR TITLE
lets switch to ignore existing

### DIFF
--- a/apps/keycloak/src/main/fabric8/deployment.yml
+++ b/apps/keycloak/src/main/fabric8/deployment.yml
@@ -114,7 +114,7 @@ spec:
         - -Dkeycloak.migration.action=import
         - -Dkeycloak.migration.provider=singleFile
         - -Dkeycloak.migration.file=/opt/jboss/keycloak/standalone/configuration/import/fabric8-realm.json
-        - -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
+        - -Dkeycloak.migration.strategy=IGNORE_EXISTING
         env:
         - name: POSTGRES_HOSTNAME
           value: keycloak-db

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -120,8 +120,7 @@ spec:
         - -Dkeycloak.migration.action=import
         - -Dkeycloak.migration.provider=singleFile
         - -Dkeycloak.migration.file=/opt/jboss/keycloak/standalone/configuration/import/fabric8-realm.json
-        - -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
-
+        - -Dkeycloak.migration.strategy=IGNORE_EXISTING
         env:
         - name: POSTGRES_HOSTNAME
           value: keycloak-db


### PR DESCRIPTION
otherwise every restart of the KC pod causes the db to be recreated which causes the WIT DB to be broken due to being inconsistent