### PR TITLE
fix gitRepo on openshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To make things easier to navigate we've created a few different organisations to
 * [fabric8-ide](https://github.com/fabric8-ide) the Fabric8 IDE projects (e.g. Eclipse Che related repos)
 * [fabric8-quickstarts](https://github.com/fabric8-quickstarts) the fabric8 community quickstarts
 * [fabric8-services](https://github.com/fabric8-services) various Services used in the fabric8 platform
-* [fabric8-images](https://github.com/fabric8-images) various docker images
+* [fabric8io-images](https://github.com/fabric8io-images) various docker images
 * [fabric8-ui](https://github.com/fabric8-ui) contains all the HTML / CSS / JavaScript / Angular modules to create the web console for fabric8: [fabric8-ui](https://github.com/fabric8-ui/fabric8-ui)
 * [fabric8io](https://github.com/fabric8io) general purpose organisation contains various things like the Java [kubernetes-client](https://github.com/fabric8io/fubernetes-client), [fabric8-maven-plugin](https://github.com/fabric8io/fabric8-maven-plugin), jenkins pipeline libraries but also numerous other things. Longer term stuff from here should probably move to more focussed organisations
 

--- a/apps/forge/src/main/fabric8/deployment.yml
+++ b/apps/forge/src/main/fabric8/deployment.yml
@@ -41,9 +41,9 @@ spec:
             path: "forge/version"
             port: 8080
         livenessProbe:
-          timeoutSeconds: 3
-          initialDelaySeconds: 120
-          failureThreshold: 10
+          timeoutSeconds: 10
+          initialDelaySeconds: 300
+          failureThreshold: 30
           httpGet:
             path: "forge/version"
             port: 8080

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -13,6 +13,20 @@ spec:
       annotations:
         pod.beta.kubernetes.io/init-containers: |-
           [{
+            "name": "git-cloner",
+            "image": "fabric8/builder-clients:0.11",
+            "imagePullPolicy": "IfNotPresent",
+            "command": [ "/bin/bash" ],
+            "args": [
+              "-c",
+              "git clone https://github.com/fabric8io/fabric8-keycloak-theme.git /keycloak-theme/login && cd /keycloak-theme/login && git checkout 61b08f0a2f4be2395bb0bbb6d16a8538f4f2b836"
+            ],
+            "volumeMounts": [{
+              "name": "keycloak-theme",
+              "mountPath": "/keycloak-theme"
+            }]
+          },
+          {
             "name": "openshift-ca-pemtokeystore",
             "image": "jimmidyson/pemtokeystore:v0.2.0",
             "imagePullPolicy": "IfNotPresent",
@@ -196,7 +210,4 @@ spec:
           - key: fabric8-realm.json
             path: config/fabric8-realm.json
       - name: keycloak-theme
-        gitRepo:
-          repository: https://github.com/fabric8io/fabric8-keycloak-theme.git
-          revision: 61b08f0a2f4be2395bb0bbb6d16a8538f4f2b836
-          directory: login
+        emptyDir: {}


### PR DESCRIPTION
lets switch to using an init container to perform the git clone inside the
    pod as gitRepo is disabled by default on OpenShift due to security (as the
    git clone happens on the host versus inside the container)