### PR TITLE
updated deployment configs included init-container for dep check

### DIFF
--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -9,16 +9,16 @@ spec:
         pod.beta.kubernetes.io/init-containers: |- 
           [
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice1",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80/api/status"]
           },
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice2",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"]
           }
           ]
     spec:

--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -4,6 +4,23 @@ metadata:
 spec:
   replicas: 1
   template:
+    metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: |- 
+          [
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80"]
+          },
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80"]
+          }
+          ]
     spec:
       containers:
       - image: "fabric8/fabric8-ui:${fabric8-ui.version}"

--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -10,13 +10,13 @@ spec:
           [
           {
             "name": "init-dependencyservice1",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80/api/status"]
           },
           {
             "name": "init-dependencyservice2",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"]
           }

--- a/apps/fabric8/src/main/fabric8/deployment.yml
+++ b/apps/fabric8/src/main/fabric8/deployment.yml
@@ -9,16 +9,16 @@ spec:
         pod.beta.kubernetes.io/init-containers: |- 
           [
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice1",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
           },
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice2",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"]
           }
           ]
     spec:

--- a/apps/fabric8/src/main/fabric8/deployment.yml
+++ b/apps/fabric8/src/main/fabric8/deployment.yml
@@ -10,13 +10,13 @@ spec:
           [
           {
             "name": "init-dependencyservice1",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
           },
           {
             "name": "init-dependencyservice2",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"]
           }

--- a/apps/fabric8/src/main/fabric8/deployment.yml
+++ b/apps/fabric8/src/main/fabric8/deployment.yml
@@ -4,6 +4,23 @@ metadata:
 spec:
   replicas: 1
   template:
+    metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: |- 
+          [
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80"]
+          },
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80"]
+          }
+          ]
     spec:
       containers:
       - image: "fabric8/fabric8-ui:${fabric8-ui.version}"

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -10,6 +10,22 @@ spec:
     service: init-tenant
   template:
     metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: |-
+          [
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://init-tenant-db:5432"]
+          },
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
+          }
+          ]
       labels:
         service: init-tenant
     spec:

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -15,13 +15,13 @@ spec:
           [
           {
             "name": "init-dependencyservice1",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://init-tenant-db:5432"]
           },
           {
             "name": "init-dependencyservice2",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
           }

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -14,13 +14,13 @@ spec:
         pod.beta.kubernetes.io/init-containers: |-
           [
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice1",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://init-tenant-db:5432"]
           },
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice2",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]

--- a/apps/keycloak/src/main/fabric8/deployment.yml
+++ b/apps/keycloak/src/main/fabric8/deployment.yml
@@ -114,7 +114,7 @@ spec:
           },
           {
               "name": "init-dependencyservice",
-              "image": "sathishvj/fabric8-dependency-wait-service",
+              "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
               "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
           }]

--- a/apps/keycloak/src/main/fabric8/deployment.yml
+++ b/apps/keycloak/src/main/fabric8/deployment.yml
@@ -111,6 +111,12 @@ spec:
               "mountPath": "/processed"
             }
             ]
+          },
+          {
+              "name": "init-dependencyservice",
+              "image": "sathishvj/fabric8-dependency-wait-service",
+              "imagePullPolicy": "IfNotPresent",
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
           }]
     spec:
       containers:

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -130,6 +130,12 @@ spec:
               "mountPath": "/processed"
             }
             ]
+          },
+          {
+              "name": "init-dependencyservice",
+              "image": "sathishvj/fabric8-dependency-wait-service",
+              "imagePullPolicy": "IfNotPresent",
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
           }]
     spec:
       containers:

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -133,7 +133,7 @@ spec:
           },
           {
               "name": "init-dependencyservice",
-              "image": "sathishvj/fabric8-dependency-wait-service",
+              "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
               "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
           }]

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -15,19 +15,19 @@ spec:
           [
           {
             "name": "init-dependencyservice1",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit-db:5432"]
           },
           {
             "name": "init-dependencyservice2",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
           },
           {
             "name": "init-dependencyservice3",
-            "image": "sathishvj/fabric8-dependency-wait-service",
+            "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
           }]

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -10,6 +10,27 @@ spec:
     service: wit
   template:
     metadata:
+      annotations:
+        pod.beta.kubernetes.io/init-containers: |-
+          [
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit-db:5432"]
+          },
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
+          },
+          {
+            "name": "init-dependencyservice",
+            "image": "sathishvj/fabric8-dependency-wait-service",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80"]
+          }]
       labels:
         service: wit
     spec:

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -14,22 +14,22 @@ spec:
         pod.beta.kubernetes.io/init-containers: |-
           [
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice1",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit-db:5432"]
           },
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice2",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
             "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
           },
           {
-            "name": "init-dependencyservice",
+            "name": "init-dependencyservice3",
             "image": "sathishvj/fabric8-dependency-wait-service",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
           }]
       labels:
         service: wit

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <almighty-core.version>0.0.1</almighty-core.version>
     <che-starter.version>7a6345</che-starter.version>
     <configmapcontroller.version>2.3.7</configmapcontroller.version>
+    <dependency-wait-service.version>v1714071</dependency-wait-service.version>
     <exposecontroller.version>2.3.19</exposecontroller.version>
     <fabric8-ui.version>v0b2d2d7</fabric8-ui.version>
     <fabric8-docker-registry.version>1.0.1</fabric8-docker-registry.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <almighty-core.version>0.0.1</almighty-core.version>
     <che-starter.version>7a6345</che-starter.version>
     <configmapcontroller.version>2.3.7</configmapcontroller.version>
-    <dependency-wait-service.version>v1714071</dependency-wait-service.version>
+    <dependency-wait-service.version>v9e22382</dependency-wait-service.version>
     <exposecontroller.version>2.3.19</exposecontroller.version>
     <fabric8-ui.version>v0b2d2d7</fabric8-ui.version>
     <fabric8-docker-registry.version>1.0.1</fabric8-docker-registry.version>


### PR DESCRIPTION
Updated the deployment.yml files which adds a dependency check using init-containers between services.
Warning: it is not currently working.

The updates will pull this (https://hub.docker.com/r/sathishvj/fabric8-dependency-wait-service/) docker image which contains this (https://github.com/fabric8-services/fabric8-dependency-wait-service) command line utility.  The image contains pg_isready which checks whether postgres is up.