### PR TITLE
lets add a nice big timeout for forge

### DIFF
--- a/apps/forge/src/main/fabric8/route.yml
+++ b/apps/forge/src/main/fabric8/route.yml
@@ -1,3 +1,6 @@
+metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: "10m"
 spec:
   to:
     kind: Service


### PR DESCRIPTION
on openshift we often get timeouts on forge REST APIs as its typically fairly slow :(
and it seems the timeouts are a little shorter on openshift 3.6.0 causing lots of failures