### PR TITLE
Dependency service - added -U param for pg_isready

### DIFF
--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -12,7 +12,7 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
           },
           {
             "name": "init-dependencyservice2",

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -17,7 +17,7 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://init-tenant-db:5432"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://f8tenant@init-tenant-db:5432"]
           },
           {
             "name": "init-dependencyservice2",

--- a/apps/keycloak/src/main/fabric8/deployment.yml
+++ b/apps/keycloak/src/main/fabric8/deployment.yml
@@ -116,7 +116,7 @@ spec:
               "name": "init-dependencyservice",
               "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
-              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"]
           }]
     spec:
       containers:

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -135,7 +135,7 @@ spec:
               "name": "init-dependencyservice",
               "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
-              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"]
           }]
     spec:
       containers:

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -17,7 +17,7 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit-db:5432"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit@wit-db:5432"]
           },
           {
             "name": "init-dependencyservice2",

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <almighty-core.version>0.0.1</almighty-core.version>
     <che-starter.version>7a6345</che-starter.version>
     <configmapcontroller.version>2.3.7</configmapcontroller.version>
-    <dependency-wait-service.version>v3496ac2</dependency-wait-service.version>
+    <dependency-wait-service.version>vbb8cb75</dependency-wait-service.version>
     <exposecontroller.version>2.3.21</exposecontroller.version>
     <fabric8-ui.version>v191e420</fabric8-ui.version>
     <fabric8-docker-registry.version>1.0.1</fabric8-docker-registry.version>


### PR DESCRIPTION
The pg_isready check wasn't working consistently earlier.  I've added a -U param, which if it exists, is passed to the pg_isready utility.  With that it I was able to test it on both minikube and minishift.