### PR TITLE
Added env vars for poll interval (default=1s) and logging verbosity

### DIFF
--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -12,13 +12,27 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           },
           {
             "name": "init-dependencyservice2",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           }
           ]
     spec:

--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -12,7 +12,7 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://init-tenant:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
           },
           {
             "name": "init-dependencyservice2",

--- a/apps/fabric8/src/main/fabric8/deployment.yml
+++ b/apps/fabric8/src/main/fabric8/deployment.yml
@@ -12,13 +12,27 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           },
           {
             "name": "init-dependencyservice2",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://wit:80/api/status"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           }
           ]
     spec:

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -17,13 +17,27 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://f8tenant@init-tenant-db:5432"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://f8tenant@init-tenant-db:5432"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           },
           {
             "name": "init-dependencyservice2",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           }
           ]
       labels:

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -17,7 +17,7 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://init-tenant-db:5432"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://f8tenant@init-tenant-db:5432"]
           },
           {
             "name": "init-dependencyservice2",

--- a/apps/keycloak/src/main/fabric8/deployment.yml
+++ b/apps/keycloak/src/main/fabric8/deployment.yml
@@ -116,7 +116,14 @@ spec:
               "name": "init-dependencyservice",
               "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
-              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"]
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"],
+              "env": [{
+                "name": "DEPENDENCY_POLL_INTERVAL",
+                "value": "1"
+              }, {
+                "name": "DEPENDENCY_LOG_VERBOSE",
+                "value": "true"
+              }]
           }]
     spec:
       containers:

--- a/apps/keycloak/src/main/fabric8/deployment.yml
+++ b/apps/keycloak/src/main/fabric8/deployment.yml
@@ -116,7 +116,7 @@ spec:
               "name": "init-dependencyservice",
               "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
-              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"]
           }]
     spec:
       containers:

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -135,7 +135,7 @@ spec:
               "name": "init-dependencyservice",
               "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
-              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak-db:5432"]
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"]
           }]
     spec:
       containers:

--- a/apps/keycloak/src/main/fabric8/deploymentConfig.yml
+++ b/apps/keycloak/src/main/fabric8/deploymentConfig.yml
@@ -135,7 +135,14 @@ spec:
               "name": "init-dependencyservice",
               "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
               "imagePullPolicy": "IfNotPresent",
-              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"]
+              "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://keycloak@keycloak-db:5432"],
+              "env": [{
+                "name": "DEPENDENCY_POLL_INTERVAL",
+                "value": "1"
+              }, {
+                "name": "DEPENDENCY_LOG_VERBOSE",
+                "value": "true"
+              }]
           }]
     spec:
       containers:

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -17,19 +17,40 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit@wit-db:5432"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit@wit-db:5432"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           },
           {
             "name": "init-dependencyservice2",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://keycloak:80"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           },
           {
             "name": "init-dependencyservice3",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 http://f8tenant:80/api/status"],
+            "env": [{
+              "name": "DEPENDENCY_POLL_INTERVAL",
+              "value": "1"
+            }, {
+              "name": "DEPENDENCY_LOG_VERBOSE",
+              "value": "true"
+            }]
           }]
       labels:
         service: wit

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -17,7 +17,7 @@ spec:
             "name": "init-dependencyservice1",
             "image": "fabric8/fabric8-dependency-wait-service:${dependency-wait-service.version}",
             "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit-db:5432"]
+            "command": ["sh", "-c", "fabric8-dependency-wait-service-linux-amd64 postgres://wit@wit-db:5432"]
           },
           {
             "name": "init-dependencyservice2",

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <almighty-core.version>0.0.1</almighty-core.version>
     <che-starter.version>7a6345</che-starter.version>
     <configmapcontroller.version>2.3.7</configmapcontroller.version>
-    <dependency-wait-service.version>vbb8cb75</dependency-wait-service.version>
+    <dependency-wait-service.version>v6632df1</dependency-wait-service.version>
     <exposecontroller.version>2.3.22</exposecontroller.version>
     <fabric8-ui.version>v4c1c517</fabric8-ui.version>
     <fabric8-docker-registry.version>1.0.1</fabric8-docker-registry.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <almighty-core.version>0.0.1</almighty-core.version>
     <che-starter.version>7a6345</che-starter.version>
     <configmapcontroller.version>2.3.7</configmapcontroller.version>
-    <dependency-wait-service.version>v3496ac2</dependency-wait-service.version>
+    <dependency-wait-service.version>vbb8cb75</dependency-wait-service.version>
     <exposecontroller.version>2.3.21</exposecontroller.version>
     <fabric8-ui.version>v191e420</fabric8-ui.version>
     <fabric8-docker-registry.version>1.0.1</fabric8-docker-registry.version>


### PR DESCRIPTION
The docker image that includes the utility (https://hub.docker.com/r/fabric8/fabric8-dependency-wait-service) has been updated and the tag updated (v6632df1) in pom.xml.