### PR TITLE
Add service-dependencies annotations.

### DIFF
--- a/apps/auth/src/main/fabric8/deployment.yml
+++ b/apps/auth/src/main/fabric8/deployment.yml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        fabric8.io/service-dependencies: "auth-db,keycloak"
         pod.beta.kubernetes.io/init-containers: |-
           [
           {

--- a/apps/fabric8/src/main/fabric8/dc.yml
+++ b/apps/fabric8/src/main/fabric8/dc.yml
@@ -6,6 +6,7 @@ spec:
   template:
     metadata:
       annotations:
+        fabric8.io/service-dependencies: "f8tenant,auth,wit"
         pod.beta.kubernetes.io/init-containers: |- 
           [
           {
@@ -143,4 +144,3 @@ spec:
             configMapKeyRef:
               name: fabric8
               key: ws.apiserver.host
-

--- a/apps/fabric8/src/main/fabric8/deployment.yml
+++ b/apps/fabric8/src/main/fabric8/deployment.yml
@@ -6,6 +6,7 @@ spec:
   template:
     metadata:
       annotations:
+        fabric8.io/service-dependencies: "f8tenant,auth,wit"
         pod.beta.kubernetes.io/init-containers: |- 
           [
           {
@@ -145,4 +146,3 @@ spec:
             configMapKeyRef:
               name: fabric8
               key: ws.apiserver.host
-

--- a/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
+++ b/apps/init-tenant/src/main/fabric8/init-tenant-deployment.yml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        fabric8.io/service-dependencies: "init-tenant-db,keycloak"
         pod.beta.kubernetes.io/init-containers: |-
           [
           {

--- a/apps/wit/src/main/fabric8/wit-deployment.yml
+++ b/apps/wit/src/main/fabric8/wit-deployment.yml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        fabric8.io/service-dependencies: "wit-db,keycloak,f8tenant,auth"
         pod.beta.kubernetes.io/init-containers: |-
           [
           {


### PR DESCRIPTION
Add an annotation for all service dependencies so we can easily query them. This would help for issue https://github.com/fabric8io/gofabric8/issues/598 and to make a tool like a tree viewer and other debugging what wait what tool.